### PR TITLE
[fix] estilos del botón CTA

### DIFF
--- a/components/button/_button-style.sass
+++ b/components/button/_button-style.sass
@@ -15,9 +15,9 @@
 		+transition
 	&-cta
 		background: $color-accent-white
-		+text-gradient-main
 		&:hover
-			background: $color-accent-white-65
+			background: $color-accent-white-80
+		&-text
 			+text-gradient-main
 	&-side
 		background: $color-accent-white-10

--- a/components/button/button-cta.js
+++ b/components/button/button-cta.js
@@ -10,7 +10,11 @@ function ButtonCta(props) {
 				className="button button-cta"
 				onClick={handleClick}
 			>
-				{props.label}
+				<span
+					className="button-cta-text"
+				>
+					{props.label}
+				</span>
 			</button>
 		</>
 	)

--- a/styles/tokens/_colors.sass
+++ b/styles/tokens/_colors.sass
@@ -12,6 +12,7 @@ $color-sky: hsla(207, 100%, 63%, 1)
 $color-sky-40: hsla(207, 100%, 70%, 1)
 $color-sky-10: hsla(208, 90%, 96%, 1)
 $color-accent-white: #FFFFFF
+$color-accent-white-80: rgba($color-accent-white, .8)
 $color-accent-white-65: rgba($color-accent-white, .65)
 $color-accent-white-50: rgba($color-accent-white, .5)
 $color-accent-white-30: rgba($color-accent-white, .3)


### PR DESCRIPTION
Antes
El botón no mostraba el background del contenedor porque era interrumpido por los estilos de su texto

Ahora
Muestra un background blanco y además el texto correctamente, pero fue necesario envolver al texto en un span